### PR TITLE
694 Ping pre fetch and related fixes

### DIFF
--- a/react/src/api/map_api.ts
+++ b/react/src/api/map_api.ts
@@ -5,6 +5,12 @@ import { API, ApiProps } from './api_interfaces';
 export const mapApi = (props: ApiProps): API => {
   const { api } = props;
 
+  const getEstimate = async (start: string, end: string): Promise<any> => {
+    const url = createUrl({api: 'get-critters-estimate', query:  `start=${start}&end=${end}`});
+    const { data } = await api.get(url);
+    return data;
+  }
+
   const getTracks = async (start: string, end: string): Promise<ITelemetryLine[]> => {
     const url = createUrl({ api: 'get-critter-tracks', query: `start=${start}&end=${end}` });
     const { data } = await api.get(url);
@@ -19,6 +25,7 @@ export const mapApi = (props: ApiProps): API => {
 
   return {
     getPings,
-    getTracks
+    getTracks,
+    getEstimate
   };
 };

--- a/react/src/api/map_api.ts
+++ b/react/src/api/map_api.ts
@@ -6,7 +6,7 @@ export const mapApi = (props: ApiProps): API => {
   const { api } = props;
 
   const getEstimate = async (start: string, end: string): Promise<any> => {
-    const url = createUrl({api: 'get-critters-estimate', query:  `start=${start}&end=${end}`});
+    const url = createUrl({api: 'get-pings-estimate', query:  `start=${start}&end=${end}`});
     const { data } = await api.get(url);
     return data;
   }

--- a/react/src/hooks/useTelemetryApi.ts
+++ b/react/src/hooks/useTelemetryApi.ts
@@ -84,6 +84,14 @@ export const useTelemetryApi = () => {
   /**
    *
    */
+  const useEstimate = (start: string, end: string): UseQueryResult<any, AxiosError> => {
+    return useQuery<any, AxiosError>(
+      ['estimate', start, end],
+      () => mapApi.getEstimate(start, end),
+      {...defaultQueryOptions, retry: false}
+    );
+  };
+
   const useTracks = (start: string, end: string): UseQueryResult<ITelemetryLine[], AxiosError> => {
     return useQuery<ITelemetryLine[], AxiosError>(
       ['tracks', start, end],
@@ -541,6 +549,7 @@ export const useTelemetryApi = () => {
     useCodes,
     useCodeDesc,
     useCodeHeaders,
+    useEstimate,
     useTracks,
     useUnassignedTracks,
     usePings,

--- a/react/src/pages/map/MapFilters.tsx
+++ b/react/src/pages/map/MapFilters.tsx
@@ -25,7 +25,8 @@ import {
   ListSubheader,
   ListItem,
   ButtonGroup,
-  Slider
+  Slider,
+  CircularProgress
 } from '@mui/material';
 import AutoComplete from 'components/form/Autocomplete';
 import clsx from 'clsx';
@@ -50,6 +51,7 @@ import { MapWeekMonthPresets, SEARCH_PRESETS } from './map_constants';
 import { getStartDate, StartDateKey } from 'utils/time';
 import makeStyles from '@mui/styles/makeStyles';
 import { useTelemetryApi } from 'hooks/useTelemetryApi';
+import { LoadingButton } from '@mui/lab';
 
 enum TabNames {
   search = 'Search',
@@ -70,6 +72,7 @@ type MapFiltersProps = {
   onClickEditUdf: () => void;
   onShowLatestPings: (b: boolean) => void;
   onShowLastFixes: (b: boolean) => void;
+  isFetching: boolean;
   // onShowUnassignedDevices: (o: ISelectMultipleData[]) => void;
 };
 const useMapStyles = makeStyles((theme) => ({
@@ -565,14 +568,17 @@ export default function MapFilters(props: MapFiltersProps): JSX.Element {
           {createFilters()}
           {createSymbolize()}
           <Box display='flex' justifyContent='flex-start' py={2}>
-            <Button
+            <LoadingButton
               color='primary'
               variant='contained'
+              loading={props.isFetching}
+              loadingPosition="center"
               className={mapStyles.btn}
+              loadingIndicator = {"Searching..."}
               disabled={disableQueryBtn()}
               onClick={isTab(symbolize) ? handleApplySymbolize : handleApplyFilters}>
               {tab}
-            </Button>
+            </LoadingButton>
             {symbolizeOrFilterPanel && (
               <Button
                 color='primary'

--- a/react/src/pages/map/MapFilters.tsx
+++ b/react/src/pages/map/MapFilters.tsx
@@ -585,7 +585,7 @@ export default function MapFilters(props: MapFiltersProps): JSX.Element {
             )}
           </Box>
           <Divider />
-          { (fetchedEstimate?.is_pings_cap) && (
+          { (fetchedEstimate?.is_pings_cap && isTab(search)) && (
           <Box display='flex' justifyContent='flex-start' py={2} whiteSpace="normal">
             <Typography paragraph variant='caption' style={{color: "red"}}>
               {"Searching over this date range will load an excessive amount of data.\n Please refine your search and try again."}

--- a/react/src/pages/map/MapFilters.tsx
+++ b/react/src/pages/map/MapFilters.tsx
@@ -26,7 +26,8 @@ import {
   ListItem,
   ButtonGroup,
   Slider,
-  CircularProgress
+  CircularProgress,
+  ThemeProvider
 } from '@mui/material';
 import AutoComplete from 'components/form/Autocomplete';
 import clsx from 'clsx';
@@ -67,6 +68,7 @@ type MapFiltersProps = {
   // pingsToDisplay: boolean;
   pings: ITelemetryPoint[];
   onCollapsePanel: () => void;
+  onApplySearch: (r: MapRange, filters: ICodeFilter[]) => void;
   onApplyFilters: (r: MapRange, filters: ICodeFilter[]) => void;
   onApplySymbolize: (s: MapFormValue, includeLatest: boolean, opacity: number) => void;
   onClickEditUdf: () => void;
@@ -83,6 +85,15 @@ const useMapStyles = makeStyles((theme) => ({
   btn: {
     minWidth: '8rem',
     marginRight: '0.5rem'
+  },
+  MuiCircularProgress: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    height: '20px !important',
+    width: '20px !important',
+    marginLeft: '-17px',
+    marginTop: '-10px'
   }
 }));
 export default function MapFilters(props: MapFiltersProps): JSX.Element {
@@ -196,7 +207,12 @@ export default function MapFilters(props: MapFiltersProps): JSX.Element {
    * @param reset force calling the parent handler with empty array
    */
   const handleApplyFilters = (event: React.MouseEvent<HTMLInputElement>, reset = false): void => {
-    props.onApplyFilters({ start, end }, reset ? [] : filters);
+    if(isTab(filter)) {
+      props.onApplyFilters({ start, end }, reset ? [] : filters);
+    }
+    else {
+      props.onApplySearch({ start, end }, reset ? [] : filters);
+    }
     // if dates were changed, it will draw all the new points, so
     // set the status of the show latest pings checkbox to false
     if (wasDatesChanged) {
@@ -568,17 +584,20 @@ export default function MapFilters(props: MapFiltersProps): JSX.Element {
           {createFilters()}
           {createSymbolize()}
           <Box display='flex' justifyContent='flex-start' py={2}>
-            <LoadingButton
-              color='primary'
-              variant='contained'
-              loading={props.isFetching}
-              loadingPosition="center"
-              className={mapStyles.btn}
-              loadingIndicator = {"Searching..."}
-              disabled={disableQueryBtn()}
-              onClick={isTab(symbolize) ? handleApplySymbolize : handleApplyFilters}>
-              {tab}
-            </LoadingButton>
+            
+              <LoadingButton
+                color='primary'
+                variant='contained'
+                loading={props.isFetching}
+                loadingPosition="end"
+                className={mapStyles.btn}
+                loadingIndicator = {<CircularProgress className={mapStyles.MuiCircularProgress}  color="inherit" size={16} />}
+                disabled={disableQueryBtn()}
+                endIcon={<Icon icon='search'/>}
+                onClick={isTab(symbolize) ? handleApplySymbolize : handleApplyFilters}>
+                {isTab(search) && props.isFetching ? "Searching..." : tab}
+              </LoadingButton>
+            
             {symbolizeOrFilterPanel && (
               <Button
                 color='primary'
@@ -593,7 +612,7 @@ export default function MapFilters(props: MapFiltersProps): JSX.Element {
           <Divider />
           { (fetchedEstimate?.is_pings_cap && isTab(search)) && (
           <Box display='flex' justifyContent='flex-start' py={2} whiteSpace="normal">
-            <Typography paragraph variant='caption' style={{color: "red"}}>
+            <Typography color="orangered">
               {"Searching over this date range will load an excessive amount of data.\n Please refine your search and try again."}
             </Typography>
           </Box>

--- a/react/src/pages/map/MapPage.tsx
+++ b/react/src/pages/map/MapPage.tsx
@@ -325,6 +325,16 @@ export default function MapPage(): JSX.Element {
   // triggered when side-panel filters are applied
   const handleApplyChangesFromFilterPanel = (newRange: MapRange, filters: ICodeFilter[]): void => {
     // if the timerange was changed, update that first. will trigger refetch
+    /*if (newRange.start !== range.start || newRange.end !== range.end) {
+      setRange(newRange);
+    }*/
+    // otherwise, update the filter state and apply the filters
+    setFilters(filters);
+    applyFiltersToPings(filters);
+  };
+
+  const handleApplyChangesFromSearchPanel = (newRange: MapRange, filters: ICodeFilter[]): void => {
+    // if the timerange was changed, update that first. will trigger refetch
     if (newRange.start !== range.start || newRange.end !== range.end) {
       setRange(newRange);
     }
@@ -535,6 +545,7 @@ export default function MapPage(): JSX.Element {
           start={range.start}
           end={range.end}
           pings={pings ?? []}
+          onApplySearch={handleApplyChangesFromSearchPanel}
           onApplyFilters={handleApplyChangesFromFilterPanel}
           onApplySymbolize={handleApplyChangesFromSymbolizePanel}
           onClickEditUdf={(): void => setShowUdfEdit((o) => !o)}

--- a/react/src/pages/map/MapPage.tsx
+++ b/react/src/pages/map/MapPage.tsx
@@ -542,6 +542,7 @@ export default function MapPage(): JSX.Element {
           onCollapsePanel={(): unknown => setTimeout(() => mapRef.current.invalidateSize(), 200)}
           onShowLatestPings={handleShowLastKnownLocation}
           onShowLastFixes={handleShowLast10Fixes}
+          isFetching={isLoadingPings}
           // collectiveUnits={getUniquePropFromPings(fetchedPings, 'collective_unit') as string[]}
         />
         <div className={'map-container'}>

--- a/react/src/pages/map/MapPage.tsx
+++ b/react/src/pages/map/MapPage.tsx
@@ -121,7 +121,7 @@ export default function MapPage(): JSX.Element {
   } = api.usePings(start, end);
   // const { isError: isErrorUPings, data: fetchedUnassignedPings } = api.useUnassignedPings(start, end);
   const { isFetching: fetchingTracks, isError: isErrorTracks, data: fetchedTracks } = api.useTracks(start, end);
-
+  
   // refetch pings when start/end times are changed
   useEffect(() => {
     // wipe the attribute panel state on refresh


### PR DESCRIPTION
This addreses 694 by sending a quick query to the server when changing dates that will make an estimate about the volume of data returned by actually searching. If the estimate is above a certain database defined threshold, the search button is disabled.

This also fixes a bug where changing the date, then applying a new filter would send a new query and filter the results of that instead of using the already existing results.

Additionally, the search button now displays a loading indicator when searching.