### PR TITLE
674-multi-accept-delegation

### DIFF
--- a/react/src/api/permission_api.ts
+++ b/react/src/api/permission_api.ts
@@ -104,7 +104,7 @@ export const permissionApi = (props: ApiProps): API => {
    * an endpoint that an admin uses to grant or deny an manager's permission request
    * currently now edit functionality exists
   */
-  const takeActionOnPermissionRequest = async (body: IExecutePermissionRequest): Promise<IUserCritterAccess> => {
+  const takeActionOnPermissionRequest = async (body: IExecutePermissionRequest[]): Promise<IUserCritterAccess> => {
     const url = createUrl({api: `execute-permission-request`});
     const { data } = await api.post(url, body);
     return data;

--- a/react/src/components/common/List.tsx
+++ b/react/src/components/common/List.tsx
@@ -2,6 +2,7 @@ import { List as MUIList, ListItem } from '@mui/material';
 
 type ListProps = {
   values: string[] | JSX.Element[];
+  disableGutters?: boolean;
 };
 
 /**
@@ -9,9 +10,9 @@ type ListProps = {
  * @param values that are rendered as the list items
  * can be either plain strings or components
 */
-const List = ({ values }: ListProps): JSX.Element => {
+const List = ({ values, disableGutters }: ListProps): JSX.Element => {
   const MakeListItem = (v: string | JSX.Element, i: number): JSX.Element => (
-    <ListItem dense key={`li-${i}`}>
+    <ListItem disableGutters={disableGutters} dense key={`li-${i}`}>
       {v}
     </ListItem>
   );

--- a/react/src/components/common/SnackbarWrapper.tsx
+++ b/react/src/components/common/SnackbarWrapper.tsx
@@ -25,7 +25,7 @@ export default function SnackbarWrapper({children}: SnackbarWrapperProps): JSX.E
   return (
     <>
       {children}
-      <Toast severity={responseState?.severity} show={showToast} message={responseState?.message} onClose={(): void => {setShowToast(false); responseState?.callback?.()}} />
+      {responseState && (<Toast severity={responseState?.severity} show={showToast} message={responseState?.message} onClose={(): void => {setShowToast(false); responseState?.callback?.()}} />)}
     </>
   )
 }

--- a/react/src/components/common/SnackbarWrapper.tsx
+++ b/react/src/components/common/SnackbarWrapper.tsx
@@ -25,7 +25,7 @@ export default function SnackbarWrapper({children}: SnackbarWrapperProps): JSX.E
   return (
     <>
       {children}
-      <Toast severity={responseState?.severity} show={showToast} message={responseState?.message} onClose={(): void => setShowToast(false)} />
+      <Toast severity={responseState?.severity} show={showToast} message={responseState?.message} onClose={(): void => {setShowToast(false); responseState?.callback?.()}} />
     </>
   )
 }

--- a/react/src/components/component_interfaces.ts
+++ b/react/src/components/component_interfaces.ts
@@ -48,6 +48,7 @@ type EditorProps<T> = EditModalBaseProps<T> & {
  */
 interface INotificationMessage extends Pick<AlertProps, 'severity'>  {
   message: string;
+  callback?: Function;
 }
 
 export type {

--- a/react/src/components/table/EditTable.tsx
+++ b/react/src/components/table/EditTable.tsx
@@ -27,6 +27,7 @@ type EditTableProps<T> = Omit<PlainTableProps<T>, 'headers'> & EditTableVisibili
   onSelectMultiple?: (n: T[]) => void;
   saveButtonText?: string;
   isMultiSelect?: boolean;
+  //selected: number[];
   //numSelected?: number;
   //onCheckAllClick?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };

--- a/react/src/components/table/EditTable.tsx
+++ b/react/src/components/table/EditTable.tsx
@@ -1,8 +1,9 @@
-import { Box, IconButton, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+import { Box, Checkbox, IconButton, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
 import { Button, Icon } from 'components/common';
 import { PlainTableProps } from 'components/table/table_interfaces';
 import TableContainer from './TableContainer';
 import './table.scss';
+import React from 'react';
 
 export type EditTableRowAction = 'add' | 'delete' | 'duplicate' | 'edit' | 'reset';
 
@@ -23,7 +24,11 @@ type EditTableProps<T> = Omit<PlainTableProps<T>, 'headers'> & EditTableVisibili
   headers: string[];
   onRowModified: (n: T, action: EditTableRowAction) => void;
   onSave: () => void;
+  onSelectMultiple?: (n: T[]) => void;
   saveButtonText?: string;
+  isMultiSelect?: boolean;
+  //numSelected?: number;
+  //onCheckAllClick?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 /**
@@ -49,14 +54,71 @@ export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
     hideDelete,
     hideEdit,
     showReset,
-    saveButtonText
+    saveButtonText,
+    isMultiSelect,
+    onSelectMultiple
+    //onCheckAllClick,
+    //numSelected
   } = props;
+
+  const [selected, setSelected] = React.useState<number[]>([]);
+
+  const isSelected = (idx: number) => { return selected.indexOf(idx) !== -1 };
+
+  const handleCheckClick = (event: React.MouseEvent<unknown>, idx: number) => {
+    const selectedIndex = selected.indexOf(idx);
+    let newSelected: number[] = [];
+
+    if (selectedIndex === -1) {
+      newSelected = newSelected.concat(selected, idx);
+    } else if (selectedIndex === 0) {
+      newSelected = newSelected.concat(selected.slice(1));
+    } else if (selectedIndex === selected.length - 1) {
+      newSelected = newSelected.concat(selected.slice(0, -1));
+    } else if (selectedIndex > 0) {
+      newSelected = newSelected.concat(
+        selected.slice(0, selectedIndex),
+        selected.slice(selectedIndex + 1),
+      );
+    }
+
+    setSelected(newSelected);
+
+    if(typeof onSelectMultiple === 'function') {
+      const selectedData: T[] = [];
+      newSelected.forEach(id => selectedData.push(data[id]));
+      onSelectMultiple(selectedData);
+    }
+  }
+
+  const handleCheckAllClick = (event: React.ChangeEvent<HTMLInputElement> ) => {
+    if(event.target.checked) {
+      const newSelected = data.map( (u, idx) => idx );
+      if (typeof onSelectMultiple === 'function') {
+        onSelectMultiple(data);
+      }
+      setSelected(newSelected);
+      return;
+    }
+    if (typeof onSelectMultiple === 'function') {
+      onSelectMultiple([]);
+    }
+    setSelected([]);
+  };
 
   return <>
     <TableContainer>
       <Table>
         <TableHead>
           <TableRow>
+              <TableCell padding="checkbox">
+                  {isMultiSelect && (
+                  <Checkbox 
+                  indeterminate={selected.length > 0 && selected.length < data.length} 
+                  checked={data.length > 0 && selected.length === data.length}
+                  onChange={handleCheckAllClick}
+                  />)}
+              </TableCell>
             {headers.map((h, idx) => (
               <TableCell align='center' key={`head-${idx}`}>
                 <strong>{h}</strong>
@@ -70,11 +132,21 @@ export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
             const ComponentsFromProps = columns.map((cb, idx) => (
               <TableCell key={`custom-${idx}`}>{cb(u)}</TableCell>
             ));
-
+            const isItemSelected = isSelected(idx);
+            
             return hideAll ? (
               <TableRow key={rowkey}>{ComponentsFromProps}</TableRow>
             ) : (
-              <TableRow key={rowkey}>
+              <TableRow key={rowkey} 
+              selected={isItemSelected} 
+              onClick={isMultiSelect ? (event) => handleCheckClick(event, idx) : () => {}}
+              >
+                <TableCell padding="checkbox">
+                  {isMultiSelect && (
+                  <Checkbox
+                  checked={isItemSelected}
+                  />)}
+                </TableCell>
                 {ComponentsFromProps}
 
                 {/* edit button */}

--- a/react/src/components/table/EditTable.tsx
+++ b/react/src/components/table/EditTable.tsx
@@ -3,7 +3,7 @@ import { Button, Icon } from 'components/common';
 import { PlainTableProps } from 'components/table/table_interfaces';
 import TableContainer from './TableContainer';
 import './table.scss';
-import React from 'react';
+import React, { useImperativeHandle } from 'react';
 
 export type EditTableRowAction = 'add' | 'delete' | 'duplicate' | 'edit' | 'reset';
 
@@ -40,7 +40,8 @@ type EditTableProps<T> = Omit<PlainTableProps<T>, 'headers'> & EditTableVisibili
  * @param onRowModified - call parent handler with the row clicked and @type {EditTableRowAction}
  * @param onSave - calls parent handler when save button clicked
  */
-export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
+//export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
+const EditTable = React.forwardRef( function<T> (props: EditTableProps<T>, ref): JSX.Element {
   const {
     canSave,
     headers,
@@ -63,6 +64,11 @@ export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
   } = props;
 
   const [selected, setSelected] = React.useState<number[]>([]);
+
+  useImperativeHandle(ref, () => ({
+    setSelected,
+    selected
+  }));
 
   const isSelected = (idx: number) => { return selected.indexOf(idx) !== -1 };
 
@@ -112,7 +118,7 @@ export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
       <Table>
         <TableHead>
           <TableRow>
-              <TableCell padding="checkbox">
+              <TableCell /*padding="checkbox"*/>
                   {isMultiSelect && (
                   <Checkbox 
                   indeterminate={selected.length > 0 && selected.length < data.length} 
@@ -121,7 +127,7 @@ export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
                   />)}
               </TableCell>
             {headers.map((h, idx) => (
-              <TableCell align='center' key={`head-${idx}`}>
+              <TableCell align='left' key={`head-${idx}`}>
                 <strong>{h}</strong>
               </TableCell>
             ))}
@@ -131,7 +137,7 @@ export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
           {data.map((u, idx) => {
             const rowkey = `body-${idx}`;
             const ComponentsFromProps = columns.map((cb, idx) => (
-              <TableCell key={`custom-${idx}`}>{cb(u)}</TableCell>
+              <TableCell align='left' key={`custom-${idx}`}>{cb(u)}</TableCell>
             ));
             const isItemSelected = isSelected(idx);
             
@@ -142,7 +148,7 @@ export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
               selected={isItemSelected} 
               onClick={isMultiSelect ? (event) => handleCheckClick(event, idx) : () => {}}
               >
-                <TableCell padding="checkbox">
+                <TableCell align='left' /*padding="checkbox"*/>
                   {isMultiSelect && (
                   <Checkbox
                   checked={isItemSelected}
@@ -208,4 +214,6 @@ export default function EditTable<T>(props: EditTableProps<T>): JSX.Element {
       </div>
     )}
   </>;
-}
+});
+
+export default EditTable;

--- a/react/src/contexts/ApiResponseContext.tsx
+++ b/react/src/contexts/ApiResponseContext.tsx
@@ -1,5 +1,6 @@
 import { INotificationMessage } from 'components/component_interfaces';
 import { useContext, createContext, useState, useEffect } from 'react';
+import { callbackify } from 'util';
 
 export const ApiResponseContext = createContext<INotificationMessage>(null);
 export const ApiResponseDispatch = createContext(null);
@@ -13,8 +14,11 @@ const ResponseProvider = (props: { children: React.ReactNode }): JSX.Element => 
   const { children } = props;
   const [state, dispatch] = useState<INotificationMessage>(null);
 
-  const clearNotif = (): void => dispatch(null);
-  const notifDisplayTime = 8000;
+  const clearNotif = (): void => {
+      dispatch(null);
+      state?.callback?.();
+  }
+  const notifDisplayTime = 3000;
   // automatically clear the notification after timer elapsed
   // or if the message is blank
   useEffect(() => {

--- a/react/src/hooks/useTelemetryApi.ts
+++ b/react/src/hooks/useTelemetryApi.ts
@@ -511,12 +511,21 @@ export const useTelemetryApi = () => {
 
   /** see permission_api doc */
   const useTakeActionOnPermissionRequest = (
+    config: UseMutationOptions<IExecutePermissionRequest[], AxiosError, IExecutePermissionRequest[]>
+  ): UseMutationResult<IExecutePermissionRequest[]> =>
+    useMutation<IExecutePermissionRequest[], AxiosError, IExecutePermissionRequest[]>(
+      (body) => permissionApi.takeActionOnPermissionRequest(body),
+      config
+    );
+
+    /*
+      const useTakeActionOnPermissionRequest = (
     config: UseMutationOptions<IUserCritterAccess, AxiosError, IExecutePermissionRequest>
   ): UseMutationResult<IUserCritterAccess> =>
     useMutation<IUserCritterAccess, AxiosError, IExecutePermissionRequest>(
       (body) => permissionApi.takeActionOnPermissionRequest(body),
       config
-    );
+    );*/
 
   /**
    * although this not a post request, use it like a mutation so it can be triggered manually

--- a/react/src/pages/permissions/AdminHandleRequestPermission.tsx
+++ b/react/src/pages/permissions/AdminHandleRequestPermission.tsx
@@ -8,7 +8,7 @@ import { useResponseDispatch } from 'contexts/ApiResponseContext';
 import useDidMountEffect from 'hooks/useDidMountEffect';
 import { useTelemetryApi } from 'hooks/useTelemetryApi';
 import AuthLayout from 'pages/layouts/AuthLayout';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { doNothing, getUniqueValuesOfT } from 'utils/common_helpers';
 import {
   groupPermissionRequests,
@@ -43,6 +43,8 @@ export default function AdminHandleRequestPermissionPage(): JSX.Element {
   //const [selectedRequestID, setSelectedRequestID] = useState<number>();
   const [selectedMultiRequestIDs, setSelectedMultiRequestIDs] = useState<number[]>([]);
 
+  const ref = useRef(null);
+
   const useStyles = makeStyles((theme) => ({
     btn: {
       backgroundColor: theme.palette.info.main,
@@ -68,6 +70,8 @@ export default function AdminHandleRequestPermissionPage(): JSX.Element {
   const onSuccess = (data: IExecutePermissionRequest[]): void => {
     const successfulRequests : number[] = data.filter(o => 'errormsg' in o == false).map(e => e.request_id);
     setRequests((o) => o.filter((req) => successfulRequests.indexOf(req.id) === -1));
+    setSelectedMultiRequestIDs([]);
+    ref?.current?.setSelected([]);
     notifRecurse(data);
   };
 
@@ -101,11 +105,13 @@ export default function AdminHandleRequestPermissionPage(): JSX.Element {
   };
 
   // if a grant/deny icon is clicked, show a confirmation modal
-  const handleShowConfirm = (request: IGroupedRequest, isGrant: boolean): void => {
+  /*const handleShowConfirm = (request: IGroupedRequest, isGrant: boolean): void => {
     setIsGrant(isGrant);
-    /*setSelectedRequestID(request.id);*/
+    setSelectedMultiRequestIDs([request.id]);
+    ref?.current?.setSelected([requests.findIndex(o => o.id == request.id)]);
+    //setSelectedRequestID(request.id);
     setShowConfirmModal((o) => !o);
-  };
+  };*/
 
   const handleShowConfirmMultiple = (isGrant: boolean): void => {
     setIsGrant(isGrant);
@@ -140,22 +146,22 @@ export default function AdminHandleRequestPermissionPage(): JSX.Element {
 
   /** components to render in the edit table */
   const Emails = (u: IGroupedRequest): JSX.Element => (
-    <List values={getUniqueValuesOfT(u.requests, 'requested_for_email')} />
+    <List disableGutters={true} values={getUniqueValuesOfT(u.requests, 'requested_for_email')} />
   );
-  const AnimalID = (u: IGroupedRequest): JSX.Element => <List values={getUniqueValuesOfT(u.requests, 'animal_id')} />;
-  const WLHID = (u: IGroupedRequest): JSX.Element => <List values={getUniqueValuesOfT(u.requests, 'wlh_id')} />;
-  const Perm = (u: IGroupedRequest): JSX.Element => <List values={getUniqueValuesOfT(u.requests, 'permission_type')} />;
+  const AnimalID = (u: IGroupedRequest): JSX.Element => <List disableGutters={true} values={getUniqueValuesOfT(u.requests, 'animal_id')} />;
+  const WLHID = (u: IGroupedRequest): JSX.Element => <List disableGutters={true} values={getUniqueValuesOfT(u.requests, 'wlh_id')} />;
+  const Perm = (u: IGroupedRequest): JSX.Element => <List disableGutters={true} values={getUniqueValuesOfT(u.requests, 'permission_type')} />;
   const RequestID = (u: IGroupedRequest): JSX.Element => <>{u.id}</>;
   const RequestedBy = (u: IGroupedRequest): JSX.Element => <>{u.requests[0].requested_by_email}</>;
   const RequestedAt = (u: IGroupedRequest): JSX.Element => <>{u.requests[0].requested_date.format(formatDay)}</>;
   const Comment = (u: IGroupedRequest): JSX.Element => <>{u.requests[0].request_comment}</>;
-  const GrantPermission = (u: IGroupedRequest): JSX.Element => {
+  /*const GrantPermission = (u: IGroupedRequest): JSX.Element => {
     return (
       <IconButton onClick={(): void => handleShowConfirm(u, true)} size="large">
         <Icon icon='done' htmlColor='green' />
       </IconButton>
     );
-  };
+  };*/
 
   /**
    * when the admin chooses to deny, show a modal asking a reason for the denial
@@ -196,11 +202,11 @@ export default function AdminHandleRequestPermissionPage(): JSX.Element {
     'WLH ID',
     'Permission',
     'Comment',
-    'Grant',
-    'Deny'
+    //'Grant',
+   // 'Deny'
   ];
 
-  const columns = [RequestedBy, RequestedAt, Emails, AnimalID, WLHID, Perm, Comment, GrantPermission];
+  const columns = [RequestedBy, RequestedAt, Emails, AnimalID, WLHID, Perm, Comment]//, GrantPermission];
 
   // also show request id in development
   if (isDev()) {
@@ -227,11 +233,15 @@ export default function AdminHandleRequestPermissionPage(): JSX.Element {
               data={requests}
               onSave={doNothing}
               onSelectMultiple={(rows: IGroupedRequest[]): void => handleSelectRow(rows)}
-              onRowModified={(u): void => handleShowConfirm(u as IGroupedRequest, false)}
+              onRowModified={(u): void => {
+                //handleShowConfirm(u as IGroupedRequest, false); 
+              }}
               hideAdd={true}
               hideEdit={true}
+              hideDelete={true}
               hideDuplicate={true}
               isMultiSelect={true}
+              ref={ref}
             />
             /*<DataTable 
             headers={PermissionRequest.requestHistoryPropsToDisplay}

--- a/react/src/types/permission.ts
+++ b/react/src/types/permission.ts
@@ -148,6 +148,8 @@ const groupPermissionRequests = (r: PermissionRequest[]): IGroupedRequest[] => {
 export interface IExecutePermissionRequest extends Pick<IPermissionRequest, 'request_id'> {
   is_grant: boolean; // whether or not to approve or deny
   was_denied_reason: string; // optional message if the request is being denied
+  requested_by_email?: string;
+  errormsg?: string;
 }
 
 /* permission-related helpers */


### PR DESCRIPTION
This branch should resolve ticket 674 regarding accepting or denying delegation requests in bulk. 

This modifies the EditTable component to include multi select capability in general.

The accept and deny columns that were there before have been removed in place of the new buttons below the table.

Snackbar components can now trigger a callback on close, allowing the chaining of many notifications one after the other.

The List component also receives an additional optional prop to fix some odd looking formatting inside the table.