### PR TITLE
Changed action menu disabled to false

### DIFF
--- a/react/src/components/common/ActionsMenu.tsx
+++ b/react/src/components/common/ActionsMenu.tsx
@@ -7,11 +7,9 @@ interface IMenuItem {
   icon?: JSX.Element;
   handleClick?: () => void;
   disableMenuItem?: boolean;
-  disableMsg?: string;
 }
 interface IActionsMenu {
   menuItems: IMenuItem[];
-  id?: number;
   disabled?: boolean;
 }
 /**

--- a/react/src/components/form/TextInput.tsx
+++ b/react/src/components/form/TextInput.tsx
@@ -60,6 +60,9 @@ export default function TextField(props: TextInputProps): JSX.Element {
     if (!v && required) {
       setErr(FormStrings.isRequired);
     }
+    else if (!!v && required) {
+      setErr('');
+    }
   };
 
   const handleChangeEmail = (email: string): void => {

--- a/react/src/pages/data/animals/CritterDataTables.tsx
+++ b/react/src/pages/data/animals/CritterDataTables.tsx
@@ -28,7 +28,7 @@ export const CritterDataTables = (): JSX.Element => {
   const [attachedAnimalData, setAttachedAnimalData] = useState<AttachedAnimal[]>([]);
   const [animalData, setAnimalData] = useState<Animal[]>([]);
 
-  const [editObj, setEditObj] = useState<Animal | AttachedAnimal>({} as AttachedAnimal);
+  const [editObj, setEditObj] = useState<Animal | AttachedAnimal>(new AttachedAnimal());
   const [deleted, setDeleted] = useState('');
   const [updated, setUpdated] = useState('');
 

--- a/react/src/pages/data/animals/CritterDataTables.tsx
+++ b/react/src/pages/data/animals/CritterDataTables.tsx
@@ -103,7 +103,7 @@ export const CritterDataTables = (): JSX.Element => {
     ];
     return (
       <ActionsMenu
-        disabled={row !== editObj}
+        disabled={false}
         menuItems={
           row instanceof AttachedAnimal ? [...defaultItems, ...attachedItems] : [...defaultItems, ...animalItems]
         }

--- a/react/src/pages/data/animals/CritterDataTables.tsx
+++ b/react/src/pages/data/animals/CritterDataTables.tsx
@@ -103,7 +103,6 @@ export const CritterDataTables = (): JSX.Element => {
     ];
     return (
       <ActionsMenu
-        disabled={false}
         menuItems={
           row instanceof AttachedAnimal ? [...defaultItems, ...attachedItems] : [...defaultItems, ...animalItems]
         }


### PR DESCRIPTION
Removes conditional disabled state for ActionsMenu in CritterDataTables such that 3 dots are clickable for all entries, regardless of which entry is currently selected