### PR TITLE
696 - Allow Telemetry Points to be Unselected After Double Clicking

### DIFF
--- a/react/src/pages/map/point_setup.ts
+++ b/react/src/pages/map/point_setup.ts
@@ -102,17 +102,21 @@ const setupLatestPingOptions = (
     pointToLayer: (feature: ITelemetryPoint, latlng: L.LatLngExpression): L.Layer => {
       const unselectedIcon = createLatestPingIcon(getFillColorByStatus(feature), getOutlineColor(feature));
       const marker = new L.Marker(latlng, { icon: unselectedIcon });
+      const enableClick = () => {
+        marker.once('click', (e) => {
+          clickHandler(e);
+          e.target.setIcon(latestSelectedPingIcon);
+        });
+      } 
       // make a hidden popup that will help deal with click events
       marker.bindPopup('', { className: 'marker-popup' }).openPopup();
       marker.on('popupclose', (e) => {
+        // marker can only be clicked once, re-enabled after pop-up closes
+        enableClick();
         closeHandler(e);
-        const { color, fillColor, opacity } = e.target.prevStyle;
-        e.target.setIcon(createLatestPingIcon(fillColor, color, opacity));
+        e.target.setIcon(unselectedIcon);
       });
-      marker.on('click', (e) => {
-        clickHandler(e);
-        e.target.setIcon(latestSelectedPingIcon);
-      });
+      enableClick();
       return marker;
     }
   };


### PR DESCRIPTION
Changes setupLatestPingOptions marker clickhandler from 'on' to 'once'. Only re-enables the clickhandler when the popup closes. Also removes dependence on e.target.prevStyle for setting the color.