### PR TITLE
835-last-telemetry-export

### DIFF
--- a/react/src/constants/strings.ts
+++ b/react/src/constants/strings.ts
@@ -316,7 +316,10 @@ const ExportStrings = {
     csvButtonLoad: 'Exporting CSV...',
     kmlButton: 'Export Data as KML',
     kmlButtonLoad: 'Exporting KML...'
-  }
+  },
+  allTelemetryButton: 'All Telemetry',
+  mostRecentTelemetryButton: 'Last Known Location',
+  attachedAnimalsOnlyCheck: 'Ongoing Deployments Only'
 };
 
 const ImportStrings = {

--- a/react/src/hooks/useTelemetryApi.ts
+++ b/react/src/hooks/useTelemetryApi.ts
@@ -34,7 +34,7 @@ import {
 } from 'api/api_interfaces';
 import { MortalityAlert, TelemetryAlert } from 'types/alert';
 import { BCTWType } from 'types/common_types';
-import { ExportQueryParams } from 'types/export';
+import { ExportAllParams, ExportQueryParams } from 'types/export';
 import { eUDFType, IUDF, UDF } from 'types/udf';
 import { ITelemetryPoint, ITelemetryLine } from 'types/map';
 import {
@@ -433,8 +433,8 @@ export const useTelemetryApi = () => {
     return useMutation<string[], AxiosError, ExportQueryParams>((body) => bulkApi.getExportData(body), config);
   };
 
-  const useExportAll = (config: UseMutationOptions<string[], AxiosError, unknown>): UseMutationResult<string[]> => {
-    return useMutation<string[], AxiosError, unknown>((body) => bulkApi.getAllExportData(body), config);
+  const useExportAll = (config: UseMutationOptions<string[], AxiosError, ExportAllParams>): UseMutationResult<string[]> => {
+    return useMutation<string[], AxiosError, ExportAllParams>((body) => bulkApi.getAllExportData(body), config);
   };
 
   /**

--- a/react/src/pages/data/bulk/ExportDownloadModal.tsx
+++ b/react/src/pages/data/bulk/ExportDownloadModal.tsx
@@ -25,6 +25,7 @@ type ExportModalProps = ModalBaseProps & {
   postGISstrings?: string[];
   critterIDs?: string[];
   children?: React.ReactNode;
+  lastTelemetryOnly: boolean;
 };
 
 enum DownloadType {

--- a/react/src/pages/data/bulk/ExportDownloadModal.tsx
+++ b/react/src/pages/data/bulk/ExportDownloadModal.tsx
@@ -16,6 +16,7 @@ import { AxiosError } from 'axios';
 import { formatAxiosError } from 'utils/errors';
 import { useResponseDispatch } from 'contexts/ApiResponseContext';
 import { ExportStrings as constants, ExportStrings } from 'constants/strings';
+import { ExportAllParams } from 'types/export';
 
 type ExportModalProps = ModalBaseProps & {
   rowEntries: IFormRowEntry[];
@@ -26,6 +27,7 @@ type ExportModalProps = ModalBaseProps & {
   critterIDs?: string[];
   children?: React.ReactNode;
   lastTelemetryOnly: boolean;
+  attachedOnly: boolean;
 };
 
 enum DownloadType {
@@ -67,7 +69,8 @@ export default function ExportDownloadModal({
   collarIDs,
   critterIDs,
   postGISstrings,
-  lastTelemetryOnly
+  lastTelemetryOnly,
+  attachedOnly
 }: ExportModalProps): JSX.Element {
   const api = useTelemetryApi();
   const showNotif = useResponseDispatch();
@@ -151,7 +154,7 @@ export default function ExportDownloadModal({
   });
 
   const handleAdvancedExport = (): void => {
-    const body = { queries: [], range: {}, polygons: [], lastTelemetryOnly: lastTelemetryOnly };
+    const body: ExportAllParams = { queries: [], range: {start: null, end: null}, polygons: [], lastTelemetryOnly: lastTelemetryOnly, attachedOnly: attachedOnly };
     for (const row of rowEntries) {
       body.queries.push({
         key: row.column,
@@ -172,7 +175,7 @@ export default function ExportDownloadModal({
   };
 
   const handleSimpleExport = (): void => {
-    const body = { queries: [], range: {}, polygons: [], lastTelemetryOnly: lastTelemetryOnly };
+    const body = { queries: [], range: {}, polygons: [], lastTelemetryOnly: lastTelemetryOnly, attachedOnly: false };
     body.queries = [{ key: 'critter_id', operator: '=', term: critterIDs }];
     body.range = {
       start: range.start.format(formatDay),

--- a/react/src/pages/data/bulk/ExportDownloadModal.tsx
+++ b/react/src/pages/data/bulk/ExportDownloadModal.tsx
@@ -66,7 +66,8 @@ export default function ExportDownloadModal({
   exportType,
   collarIDs,
   critterIDs,
-  postGISstrings
+  postGISstrings,
+  lastTelemetryOnly
 }: ExportModalProps): JSX.Element {
   const api = useTelemetryApi();
   const showNotif = useResponseDispatch();
@@ -150,7 +151,7 @@ export default function ExportDownloadModal({
   });
 
   const handleAdvancedExport = (): void => {
-    const body = { queries: [], range: {}, polygons: [] };
+    const body = { queries: [], range: {}, polygons: [], lastTelemetryOnly: lastTelemetryOnly };
     for (const row of rowEntries) {
       body.queries.push({
         key: row.column,
@@ -171,7 +172,7 @@ export default function ExportDownloadModal({
   };
 
   const handleSimpleExport = (): void => {
-    const body = { queries: [], range: {}, polygons: [] };
+    const body = { queries: [], range: {}, polygons: [], lastTelemetryOnly: lastTelemetryOnly };
     body.queries = [{ key: 'critter_id', operator: '=', term: critterIDs }];
     body.range = {
       start: range.start.format(formatDay),

--- a/react/src/pages/data/bulk/ExportV2.tsx
+++ b/react/src/pages/data/bulk/ExportV2.tsx
@@ -93,6 +93,7 @@ export default function ExportPageV2(): JSX.Element {
   //const [selectedLifetime, setSelectedLifetime] = useState(false);
   const [exportRangeType, setExportRangeType] = useState<ExportRangeType>('date_range');
   const [currentGeometry, setCurrentGeometry] = useState<string[]>([]);
+  const [attachedOnly, setAttachedOnly] = useState<boolean>(false);
 
   const handleDrawShape = (features: L.FeatureGroup): void => {
     const clipper = features.toGeoJSON() as FeatureCollection;
@@ -173,17 +174,17 @@ export default function ExportPageV2(): JSX.Element {
             name="export-radio"
             value={exportRangeType}
           >
-            <FormControlLabel value='lifetime' control={<Radio onClick={handleRadioChange}/>} label="All Telemetry"/>
-            <FormControlLabel value='last_telemetry' control={<Radio onClick={handleRadioChange} />} label="Last Telemetry"/>
+            <FormControlLabel 
+              value='lifetime' 
+              control={<Radio onClick={handleRadioChange}/>} 
+              label={ExportStrings.allTelemetryButton}
+            />
+            <FormControlLabel 
+              value='last_telemetry' 
+              control={<Radio onClick={handleRadioChange} />} 
+              label={ExportStrings.mostRecentTelemetryButton}
+            />
           </RadioGroup>
-          {
-            /*<Checkbox
-            propName={'animalLifetime'}
-            label={ExportStrings.checkboxLabel}
-            initialValue={selectedLifetime}
-            changeHandler={() => setSelectedLifetime((o) => !o)}
-          />*/
-        }
         </Box>
       </Box>
     );
@@ -217,6 +218,12 @@ export default function ExportPageV2(): JSX.Element {
     return (
       <Box>
         {datePicker()}
+        <Checkbox 
+          propName={'attached-only-checkbox'}
+          label={ExportStrings.attachedAnimalsOnlyCheck} 
+          initialValue={false} 
+          changeHandler={() => setAttachedOnly(!attachedOnly)}        
+        />
         <Box className={styles.queryRegionBox}>
           <SubHeader dark size='small' text={ExportStrings.queryBuilderHeader} />
           <Box pt={2}>
@@ -266,6 +273,7 @@ export default function ExportPageV2(): JSX.Element {
         collarIDs={collarIDs}
         postGISstrings={currentGeometry}
         lastTelemetryOnly={exportRangeType === 'last_telemetry'}
+        attachedOnly={attachedOnly}
         range={{
           start: exportRangeType !== 'date_range' ? dayjs('1970-01-01') : start,
           end: exportRangeType !== 'date_range' ? dayjs() : end

--- a/react/src/types/export.ts
+++ b/react/src/types/export.ts
@@ -14,6 +14,21 @@ interface ExportQueryParams {
   range?: MapRange;
 }
 
+interface ExportQuery {
+  key: string,
+  operator: string,
+  term: string[]
+}
+
+interface ExportAllParams {
+  queries: ExportQuery[];
+  range: MapRange;
+  polygons: string[];
+  lastTelemetryOnly: boolean;
+  attachedOnly: boolean;
+}
+
 export type {
-  ExportQueryParams
+  ExportQueryParams,
+  ExportAllParams
 }


### PR DESCRIPTION
This PR changes the UI of the Export page to include options for exporting only the last known location of relevant animals and/or only animals with a collar attached. 

All Telemetry has been changed from a checkbox to a pair of radio buttons alongside Last Known Location. The button for attached animals only is a checkbox and can be used with either radio option. The attached animals only checkbox is only available on Advanced Export since animals in Quick Export are already guaranteed to be attached. 