### PR TITLE
887 export dropdowns fix

### DIFF
--- a/react/src/api/api_endpoint_urls.ts
+++ b/react/src/api/api_endpoint_urls.ts
@@ -16,6 +16,7 @@ const upsertCritterEndpoint              = 'upsert-animal';
 const upsertDeviceEndpoint               = 'upsert-collar';
 const upsertAlertEndpoint                = 'update-user-alert';
 const getCritterEndpoint                 = 'get-animals';
+const getAttachedHistoricEndpoint        = 'get-attached-historic'
 const submitOnboardingRequest            = 'submit-onboarding-request';
 const getOnboardingRequests              = 'onboarding-requests';
 const handleOnboardingRequest            = 'handle-onboarding-request';
@@ -42,4 +43,5 @@ export {
   getCurrentOnboardStatus,
   handleOnboardingRequest,
   triggerTelemetryFetch,
+  getAttachedHistoricEndpoint
 }

--- a/react/src/api/critter_api.ts
+++ b/react/src/api/critter_api.ts
@@ -1,4 +1,4 @@
-import { getCritterEndpoint, upsertCritterEndpoint } from 'api/api_endpoint_urls';
+import { getAttachedHistoricEndpoint, getCritterEndpoint, upsertCritterEndpoint } from 'api/api_endpoint_urls';
 import { createUrl, postJSON } from 'api/api_helpers';
 import { API, ApiProps, IBulkUploadResults, IUpsertPayload } from 'api/api_interfaces';
 import { plainToClass } from 'class-transformer';
@@ -58,9 +58,16 @@ export const critterApi = (props: ApiProps): API => {
     return data.map((json: Critter[]) => plainToClass(Critter, json));
   };
 
+  const getAssignedCrittersHistoric = async (): Promise<AttachedCritter[]> => {
+    const url = createUrl({api: getAttachedHistoricEndpoint});
+    const { data } = await api.get(url);
+    return data;
+  }
+
   return {
     getCritters,
     getCritterHistory,
-    upsertCritter
+    upsertCritter,
+    getAssignedCrittersHistoric
   };
 };

--- a/react/src/components/form/QueryBuilder.tsx
+++ b/react/src/components/form/QueryBuilder.tsx
@@ -104,8 +104,7 @@ export default function QueryBuilder<T extends ISelectMultipleData>(props: IQuer
       const uniqueItemsForColumn: any[] = [];
       const uniqueItemsCollectionUnits: any[] = [];
       
-      
-      if(col === 'collection_unit') {
+      if(col === 'collection_units') {
         const flattenCollectionUnits = data.map(r => r.collection_units).filter(v => v).flat();
         for(const f of flattenCollectionUnits) {
           if(!uniqueItemsCollectionUnits.find(a => a.collection_unit_id === f.collection_unit_id)) {

--- a/react/src/components/form/QueryBuilder.tsx
+++ b/react/src/components/form/QueryBuilder.tsx
@@ -105,12 +105,19 @@ export default function QueryBuilder<T extends ISelectMultipleData>(props: IQuer
       const uniqueItemsCollectionUnits: any[] = [];
       
       if(col === 'collection_units') {
-        const flattenCollectionUnits = data.map(r => r.collection_units).filter(v => v).flat();
-        for(const f of flattenCollectionUnits) {
-          if(!uniqueItemsCollectionUnits.find(a => a.collection_unit_id === f.collection_unit_id)) {
-            uniqueItemsCollectionUnits.push(f);
+        const tempDict = {};
+        for(const d of data) {
+          if(d.collection_units) {
+            for(const c of d.collection_units) {
+              const tRow = rows.find(r => r.column === 'taxon')
+              if(tRow && !tRow.value.includes(d.taxon)) {
+                continue;
+              }
+              tempDict[c.collection_unit_id] = {...c, taxon: d.taxon};
+            }
           }
         }
+        uniqueItemsCollectionUnits.push(...Object.values(tempDict));
       }
       else {
         uniqueItemsForColumn.push(...data.map((o) => o[col]).filter((v, i, a) => v && a.indexOf(v) === i));
@@ -127,7 +134,7 @@ export default function QueryBuilder<T extends ISelectMultipleData>(props: IQuer
         return {
           id: i + uniqueItemsForColumn.length,
           value: c.collection_unit_id,
-          displayLabel: `${c.category_name} | ${c.unit_name}`
+          displayLabel: `${c.taxon} | ${c.category_name} | ${c.unit_name}`
         }
       }) ]
     } else {

--- a/react/src/hooks/useTelemetryApi.ts
+++ b/react/src/hooks/useTelemetryApi.ts
@@ -308,6 +308,14 @@ export const useTelemetryApi = () => {
     );
   };
 
+  const useAssignedCrittersHistoric = (config?: Record<string, unknown>): UseQueryResult<AttachedCritter[]> => {
+    return useQuery<AttachedCritter[], AxiosError>(
+      ['critters_assigned_historic'],
+      () => critterApi.getAssignedCrittersHistoric(),
+      {...config}
+    )
+  }
+
   // minimize code refetching
   const codeOptions = { ...defaultQueryOptions, refetchOnMount: false };
 
@@ -744,6 +752,7 @@ export const useTelemetryApi = () => {
     useSubmitOnboardingRequest,
     useHandleOnboardingRequest,
     useTriggerVendorTelemetry,
-    useDeleteMarking
+    useDeleteMarking,
+    useAssignedCrittersHistoric
   };
 };

--- a/react/src/pages/data/bulk/ExportDownloadModal.tsx
+++ b/react/src/pages/data/bulk/ExportDownloadModal.tsx
@@ -133,17 +133,6 @@ export default function ExportDownloadModal({
     handleClose(false);
   };
 
-  const operatorTranslation = (operatorWord: QueryBuilderOperator | ''): string => {
-    switch (operatorWord) {
-      case 'Equals':
-        return '=';
-      case 'Not Equals':
-        return '<>';
-      default:
-        return '';
-    }
-  };
-
   useDidMountEffect(() => {
     startRequest();
   }, [downloadType]);

--- a/react/src/pages/data/bulk/ExportV2.tsx
+++ b/react/src/pages/data/bulk/ExportV2.tsx
@@ -110,7 +110,7 @@ export default function ExportPageV2(): JSX.Element {
     }
   };
 
-  const { data: crittersData, isSuccess: critterSuccess } = api.useAssignedCritters(0);
+  const { data: crittersData, isSuccess: critterSuccess } = api.useAssignedCrittersHistoric();
 
   const handleChangeDate = (v: InboundObj): void => {
     const [key, value] = parseFormChangeResult(v);


### PR DESCRIPTION
This fixes the population of the dropdowns in BCTW by making the export page use a different query hook than the previous assigned animals endpoint. There's also a slight update to the way the population unit dropdowns are handled so that you can see which Taxon each unit belongs to. The list also becomes more limited once you start choosing things from the Taxon dropdown.