### PR TITLE
894 taxon edit page

### DIFF
--- a/react/src/api/critterbase_api.ts
+++ b/react/src/api/critterbase_api.ts
@@ -29,6 +29,14 @@ export const critterbaseApi = (props: ApiProps): API => {
     return data;
   };
 
+  const verifyMarkingsAgainstTaxon = async (
+    taxon_id: string,
+    markings: IMarking[]
+  ) => {
+    const { data } = await api.post(`${CbRouters.markings}/verify`, {taxon_id: taxon_id, markings: markings});
+    return data;
+  }
+
   const upsertCritter = async (critter: IUpsertPayload<Critter>): Promise<Critter> => {
     // critter.body.sex = 'test';
     const { data } = await api.put(`${CbRouters.critters}/${critter.body.critter_id}${detailedFormat}`, critter.body);
@@ -50,6 +58,7 @@ export const critterbaseApi = (props: ApiProps): API => {
     getLookupTableOptions,
     upsertCritter,
     bulkUpdate,
-    deleteMarking
+    deleteMarking,
+    verifyMarkingsAgainstTaxon
   };
 };

--- a/react/src/constants/strings.ts
+++ b/react/src/constants/strings.ts
@@ -25,7 +25,9 @@ const CritterStrings = {
   },
   collaredAnimals: 'Collared Animals',
   nonCollaredAnimals: 'Non-collared Animals',
-  manageMyAnimals: 'Manage my Animals'
+  manageMyAnimals: 'Manage my Animals',
+  markingIncompatibility: 'It is not possible to assign this taxon to this critter as the critter has markings and/or measurements that are not compatible with the desired taxon.',
+  removeMarkingsPlease: 'The markings below must be removed before you are allowed to switch taxons.'
 };
 
 const LatestDataRetrieval = {

--- a/react/src/critterbase/components/CbCollectionUnitInputs.tsx
+++ b/react/src/critterbase/components/CbCollectionUnitInputs.tsx
@@ -25,7 +25,8 @@ export const CbCollectionUnitInputs = ({
   }, [collection_units])
 
   const onChange = (v: InboundObj, category_id: string): void => {
-    const [key, value] = parseFormChangeResult(v);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [key, value] = parseFormChangeResult(v); //Easier to just disable for this line so we can still use the array destructuring
     if(!value) {
       return;
     }
@@ -39,7 +40,6 @@ export const CbCollectionUnitInputs = ({
         collection_category_id: category_id
       })
     }
-    console.log(`State of internalLookup: ${JSON.stringify(internalLookup, null, 2)}`)
   }
 
   return (

--- a/react/src/critterbase/components/CbSelect.tsx
+++ b/react/src/critterbase/components/CbSelect.tsx
@@ -61,8 +61,7 @@ export const CbSelect = ({
 
   const handleSelect = async (id?: string, label?: string): Promise<void> => {
     const shouldChange = await isSelectionAllowed?.(id);
-    console.log('handleSelect fired')
-    if(!shouldChange) {
+    if(typeof isSelectionAllowed === 'function' && !shouldChange) {
       return;
     }
     const hasProps = id && label;
@@ -86,7 +85,7 @@ export const CbSelect = ({
           const valueId = typeof val === 'string' ? val : val.id;
           const value = typeof val === 'string' ? val : val.value;
           return (
-            <MenuItem value={valueId} key={`${val}-${idx}`} onClick={() => handleSelect(valueId, value)}>
+            <MenuItem value={valueId} key={`${val}-${idx}`} onClick={async () => await handleSelect(valueId, value)}>
               {capitalize(value)}
             </MenuItem>
           );

--- a/react/src/critterbase/components/CbSelect.tsx
+++ b/react/src/critterbase/components/CbSelect.tsx
@@ -13,6 +13,7 @@ export type CbSelectProps = Omit<CreateInputProps, 'type'> & {
   cbRouteKey: ICbRouteKey;
   handleRoute?: CbRouteStatusHandler;
   query: string;
+  isSelectionAllowed?: (newval: unknown) => boolean | Promise<boolean>
 };
 export const CbSelect = ({
   cbRouteKey,
@@ -23,7 +24,8 @@ export const CbSelect = ({
   handleRoute,
   label,
   disabled,
-  query
+  query,
+  isSelectionAllowed
 }: CbSelectProps): JSX.Element => {
   const cbApi = useTelemetryApi();
   const { data, isError, isLoading, isSuccess, status } = cbApi.useCritterbaseSelectOptions(cbRouteKey, query);
@@ -57,7 +59,12 @@ export const CbSelect = ({
     handleChange(ret);
   };
 
-  const handleSelect = (id?: string, label?: string): void => {
+  const handleSelect = async (id?: string, label?: string): Promise<void> => {
+    const shouldChange = await isSelectionAllowed?.(id);
+    console.log('handleSelect fired')
+    if(!shouldChange) {
+      return;
+    }
     const hasProps = id && label;
     const a = { id, label };
     setSelected(hasProps ? a.id : '');

--- a/react/src/hooks/useTelemetryApi.ts
+++ b/react/src/hooks/useTelemetryApi.ts
@@ -122,6 +122,14 @@ export const useTelemetryApi = () => {
     );
   };
 
+  const useVerifyMarkingsAgainstTaxon = (
+    config: UseMutationOptions<string[], AxiosError, {taxon_id: string, markings: IMarking}>
+  ): UseMutationResult<string[]> => 
+  useMutation<string[], AxiosError, {taxon_id: string, markings: IMarking}>(
+    ({taxon_id, markings}) => critterbaseApi.verifyMarkingsAgainstTaxon(taxon_id, markings),
+    config
+  );
+
   /** upsert an animal */
   const useSaveCritterbaseCritter = (
     config: UseMutationOptions<IBulkUploadResults<Critter>, AxiosError, IUpsertPayload<Critter>>
@@ -758,6 +766,7 @@ export const useTelemetryApi = () => {
     useTriggerVendorTelemetry,
     useAssignedCrittersHistoric,
     useBulkUpdateCritterbaseCritter,
-    useDeleteMarking
+    useDeleteMarking,
+    useVerifyMarkingsAgainstTaxon
   };
 };

--- a/react/src/pages/data/animals/EditCritter.tsx
+++ b/react/src/pages/data/animals/EditCritter.tsx
@@ -44,6 +44,8 @@ export default function EditCritter(
 
   const critterbaseSave = async (payload) => {
     const { body } = payload;
+    console.log(`Here is editingObj: ${JSON.stringify(editing, null, 2)}`)
+    console.log('Received this body: ' + JSON.stringify(body, null, 2));
     const new_critter = {
       critter_id: body.critter_id,
       animal_id: body.animal_id,
@@ -62,7 +64,8 @@ export default function EditCritter(
       critters: [],
       captures: [],
       mortalities: [],
-      markings: []
+      markings: [],
+      collections: []
     };
     if (hasChangedProperties(old_critter, new_critter)) {
       finalPayload.critters.push(new_critter);
@@ -118,12 +121,19 @@ export default function EditCritter(
         }
         finalPayload.markings.push(m);
       }
-      /*finalPayload.markings = body.marking.map(m => {
-          m.critter_id = body.critter_id;
-          return omitNull(m)
-        });*/
     }
 
+    if(body.collection_units) {
+        for(const c of body.collection_units) {
+          if(old_critter.taxon_id !== new_critter.taxon_id && c.critter_collection_unit_id) {
+            c._delete = true;
+          }
+          c.critter_id = new_critter.critter_id;
+        }
+        finalPayload.collections = body.collection_units;
+    }
+    
+    console.log(`Here is the final payload ${JSON.stringify(finalPayload, null, 2)}`)
     const r = await onSave(finalPayload);
     return r;
   };
@@ -194,6 +204,7 @@ export default function EditCritter(
         {(handlerFromContext): JSX.Element => {
           // override the modal's onChange function
           const onChange = (v: InboundObj): void => {
+            console.log(`ChangeContext inbound obj: ${JSON.stringify(v, null, 2)}`)
             const [key, value] = parseFormChangeResult<AttachedCritter>(v);
             if (key === 'taxon_id') {
               setTaxonId(value as string);


### PR DESCRIPTION
This PR modifies the Edit Critter page to correctly handle the case where the taxon changes, which affects the validity of collection units and markings. If you try to change the taxon of a critter that has markings which have fields not inherited by the new taxon, a pop-up will show and you will be prevented from switching. Removing the offending markings allows you to switch. Switching taxons successfully will also change the available collection units now. There is a check in the payload builder that will add _delete keys to markings on the condition that they already have primary keys and the new payload has a different taxon_id from the existing critter entry. 