### PR TITLE
886 critterbase login

### DIFF
--- a/backend/js/server.js
+++ b/backend/js/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const axios = require("axios");
 const cors = require("cors");
 const express = require("express");
@@ -140,6 +141,7 @@ const proxyApi = function (req, res, next) {
     // connect to API without using Keycloak authentication
     url = `${apiHost}:${apiPort}/${endpoint}?${parameters}`;
   }
+
 
   const errHandler = (err) => {
     const { response } = err;

--- a/react/src/api/critterbase_api.ts
+++ b/react/src/api/critterbase_api.ts
@@ -46,10 +46,22 @@ export const critterbaseApi = (props: ApiProps): API => {
     return data;
   };
 
+  const loginToCritterbase = async (system_user_id: string | undefined, keycloak_id: string | undefined): Promise<Record<string, unknown>> => {
+    try {
+      const { data } = await api.post(`${CbRouters.login}`, {system_user_id: system_user_id, keycloak_uuid: keycloak_id, system_name: 'BCTW'});
+      return data;
+    }
+    catch(e) {
+      const { data } = await api.post(`${CbRouters.signup}`, {system_user_id: system_user_id, keycloak_uuid: keycloak_id, system_name: 'BCTW'});
+      return data;
+    }
+  }
+
   return {
     getLookupTableOptions,
     upsertCritter,
     bulkUpdate,
-    deleteMarking
+    deleteMarking,
+    loginToCritterbase
   };
 };

--- a/react/src/api/user_api.ts
+++ b/react/src/api/user_api.ts
@@ -44,7 +44,6 @@ export const userApi = (props: ApiProps): API => {
     }
     const url = createUrl({ api: 'session-info' });
     const { data } = await api.get(url);
-    //console.log('retrieve session info', data);
     return data;
   };
 

--- a/react/src/contexts/UserContext.tsx
+++ b/react/src/contexts/UserContext.tsx
@@ -46,6 +46,18 @@ export const UserStateContextProvider: React.FC = (props) => {
     status: sessionStatus,
     error: sessionError
   } = api.useUserSessionInfo();
+
+  const {data: critterLoginData, status: critterLoginStatus } = api.useCritterbaseSessionInfo(
+    sessionData?.username, 
+    sessionData?.keycloak_guid, 
+    {enabled: sessionStatus === 'success' && userStatus === 'success' && !userError} 
+    //Ensure keycloak session and user hook retrieve their info successfully before logging into critterbase
+    //Shouldn't sign people up if they don't have access to bctw yet
+  );
+
+  useEffect(() => {
+    console.log(`Status of Critter login hook: ${JSON.stringify(critterLoginData)}, ${critterLoginStatus}`);
+  }, [critterLoginData, critterLoginStatus ])
   // setup the mutation, used if the user row in the database is out of date
   const onSuccess = (v: User): void => {
     console.log('UserContext: new user object is', v);
@@ -69,6 +81,7 @@ export const UserStateContextProvider: React.FC = (props) => {
       setSession(sessionData);
       setUserContext((o) => ({ ...o, session: sessionData }));
     }
+    console.log(`Session status: ${sessionStatus} ${sessionData}`);
   }, [sessionStatus]);
 
   /**

--- a/react/src/critterbase/routes.ts
+++ b/react/src/critterbase/routes.ts
@@ -11,6 +11,8 @@ export const CbRouters = {
   markings: '/markings',
   xref: '/xref',
   bulk: '/bulk',
+  login: '/login',
+  signup: '/signup',
 
   get lookupsEnum(): string {
     return this.lookups + '/enum';

--- a/react/src/hooks/useTelemetryApi.ts
+++ b/react/src/hooks/useTelemetryApi.ts
@@ -24,7 +24,7 @@ import { AttachedCritter, Critter, eCritterFetchType, IMarking } from 'types/ani
 import { ICode, ICodeHeader } from 'types/code';
 import { AttachedCollar, Collar, DeviceWithVectronicKeyX, VectronicKeyX } from 'types/collar';
 import { AttachDeviceInput, CollarHistory, RemoveDeviceInput } from 'types/collar_history';
-import { IKeyCloakSessionInfo, User } from 'types/user';
+import { ICritterbaseLoginResponse, IKeyCloakSessionInfo, User } from 'types/user';
 
 import {
   IBulkUploadResults,
@@ -397,6 +397,14 @@ export const useTelemetryApi = () => {
     );
   };
 
+  const useCritterbaseSessionInfo = (user_id: string, keycloak_id: string, config?: QueryEnabled): UseQueryResult<ICritterbaseLoginResponse, AxiosError> => {
+    return useQuery<ICritterbaseLoginResponse, AxiosError>(
+      ['critterbase-session', user_id, keycloak_id],
+      () => critterbaseApi.loginToCritterbase(user_id, keycloak_id),
+      {...defaultQueryOptions, ...config}
+    )
+  }
+
   /**
    * requires admin role
    * @returns a list of all users
@@ -758,6 +766,7 @@ export const useTelemetryApi = () => {
     useTriggerVendorTelemetry,
     useAssignedCrittersHistoric,
     useBulkUpdateCritterbaseCritter,
-    useDeleteMarking
+    useDeleteMarking,
+    useCritterbaseSessionInfo
   };
 };

--- a/react/src/types/user.ts
+++ b/react/src/types/user.ts
@@ -24,6 +24,10 @@ export interface IKeyCloakSessionInfo {
   keycloak_guid: string;
 }
 
+export interface ICritterbaseLoginResponse {
+  user_id: string
+}
+
 // all user classes implement
 type UserBaseType = {
   firstname: string;


### PR DESCRIPTION
This commit adds hooks to establish a login with critterbase in UserContext, same place that session info is retrieved. It is disabled when the UserContext is in an error state, which happens when you pass keycloak but still get stuck at the bctw sign in page. If the login fails, the hook will automatically attempt a sign up instead.