### PR TITLE
900 assign animal per row

### DIFF
--- a/react/src/api/api_interfaces.ts
+++ b/react/src/api/api_interfaces.ts
@@ -70,7 +70,7 @@ type XLSXPayload = {
 };
 
 type ParsedXLSXRowResult = {
-  row: AnimalCollar & {possible_critter_ids: string[], selected_critter_id?: string};
+  row: AnimalCollar & {possible_critters: Partial<Critter>[], selected_critter_id?: string};
   errors: ParsedXLSXCellError;
   warnings: WarningInfo[];
   success: boolean;

--- a/react/src/api/api_interfaces.ts
+++ b/react/src/api/api_interfaces.ts
@@ -70,7 +70,7 @@ type XLSXPayload = {
 };
 
 type ParsedXLSXRowResult = {
-  row: AnimalCollar;
+  row: AnimalCollar & {possible_critter_ids: string[], selected_critter_id?: string};
   errors: ParsedXLSXCellError;
   warnings: WarningInfo[];
   success: boolean;

--- a/react/src/components/form/BasicSelect.tsx
+++ b/react/src/components/form/BasicSelect.tsx
@@ -20,8 +20,9 @@ export default function Select({
   values,
   triggerReset,
   sx,
+  disabled,
   defaultValue = '',
-  className = 'select-control-small'
+  className = 'select-control-small',
 }: BasicSelectProps): JSX.Element {
   const [selected, setSelected] = useState(defaultValue);
 
@@ -37,7 +38,7 @@ export default function Select({
   return (
     <FormControl className={className} size='small' sx={sx}>
       <InputLabel>{label}</InputLabel>
-      <MUISelect onChange={onChange} value={selected} required={true}>
+      <MUISelect disabled={disabled} onChange={onChange} value={selected} required={true}>
         {values.map((v, idx) => (
           <MenuItem key={`${idx}-${v}`} value={v}>
             {v}

--- a/react/src/components/form/BasicSelect.tsx
+++ b/react/src/components/form/BasicSelect.tsx
@@ -8,6 +8,7 @@ export type SharedSelectProps = SelectProps & {
 
 type BasicSelectProps = SharedSelectProps & {
   values: string[];
+  valueLabels?: string[];
   handleChange: (v: string) => void;
 };
 
@@ -23,6 +24,7 @@ export default function Select({
   disabled,
   defaultValue = '',
   className = 'select-control-small',
+  valueLabels = []
 }: BasicSelectProps): JSX.Element {
   const [selected, setSelected] = useState(defaultValue);
 
@@ -41,7 +43,7 @@ export default function Select({
       <MUISelect disabled={disabled} onChange={onChange} value={selected} required={true}>
         {values.map((v, idx) => (
           <MenuItem key={`${idx}-${v}`} value={v}>
-            {v}
+            {valueLabels?.[idx] ?? v}
           </MenuItem>
         ))}
       </MUISelect>

--- a/react/src/components/form/Date.tsx
+++ b/react/src/components/form/Date.tsx
@@ -2,8 +2,8 @@ import { DesktopDatePicker } from '@mui/lab';
 import AdapterDateFns from '@mui/lab/AdapterDayjs';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
 import TextField, { StandardTextFieldProps } from '@mui/material/TextField';
-import dayjs, { Dayjs } from 'dayjs';
-import { useEffect, useState } from 'react';
+import { Dayjs } from 'dayjs';
+import { useState } from 'react';
 import { FormBaseProps } from 'types/form_types';
 import { formatDay } from 'utils/time';
 

--- a/react/src/components/table/HighlightTable.tsx
+++ b/react/src/components/table/HighlightTable.tsx
@@ -1,7 +1,6 @@
 import { lighten, Table, TableBody, TableCell, TableRow, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { Tooltip } from 'components/common';
-import Select from 'components/form/BasicSelect';
 import { formatTableCell, getComparator, stableSort } from 'components/table/table_helpers';
 import { Order, PlainTableProps } from 'components/table/table_interfaces';
 import TableContainer from 'components/table/TableContainer';

--- a/react/src/components/table/HighlightTable.tsx
+++ b/react/src/components/table/HighlightTable.tsx
@@ -1,6 +1,7 @@
 import { lighten, Table, TableBody, TableCell, TableRow, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { Tooltip } from 'components/common';
+import Select from 'components/form/BasicSelect';
 import { formatTableCell, getComparator, stableSort } from 'components/table/table_helpers';
 import { Order, PlainTableProps } from 'components/table/table_interfaces';
 import TableContainer from 'components/table/TableContainer';
@@ -54,6 +55,7 @@ export default function HighlightTable<T extends BCTWBase<T>>({
       onSelectCell(row_idx, String(cellname));
     }
   };
+
   return (
     <TableContainer>
       <Table className={'table'} size='small'>

--- a/react/src/critterbase/components/CbSelect.tsx
+++ b/react/src/critterbase/components/CbSelect.tsx
@@ -40,7 +40,6 @@ export const CbSelect = ({
   const labelOverride = label ?? columnToHeader(cbRouteKey);
 
   useEffect(() => {
-    prop === 'proximate_predated_by_taxon_id' && console.log({value});
     if (selected == value) return;
     if (typeof value === 'string') {
       setSelected(value);

--- a/react/src/pages/data/bulk/ImportTabs.tsx
+++ b/react/src/pages/data/bulk/ImportTabs.tsx
@@ -1,5 +1,5 @@
 import { LoadingButton } from '@mui/lab';
-import { Box, Button, CircularProgress, Paper, Theme, Typography } from '@mui/material';
+import { Box, Button, CircularProgress,  Paper, Theme, Typography } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { createUrl } from 'api/api_helpers';
 import { CellErrorDescriptor, ParsedXLSXSheetResult, WarningInfo } from 'api/api_interfaces';
@@ -20,6 +20,7 @@ import { useEffect, useState } from 'react';
 import { columnToHeader } from 'utils/common_helpers';
 import WarningPromptsBanner from './WarningPromptsBanner';
 import { collectErrorsFromResults, collectWarningsFromResults, computeXLSXCol, getAllUniqueKeys } from './xlsx_helpers';
+import { Critter } from 'types/animal';
 import Select from 'components/form/BasicSelect';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -151,15 +152,19 @@ const ImportAndPreviewTab = (props: ImportTabProps & { sheetIndex: SheetNames; h
     return headers;
   };
 
-  const selectCritterDropdownElement = (possible_ids: string[], defaultVal: string, onChange: (selectedVal: string) => void): JSX.Element => {
-    const possible_items = possible_ids.length == 0 ? ['New Critter'] : [...possible_ids, 'New Critter' ];
+  const selectCritterDropdownElement = (possible_critters: Partial<Critter>[], defaultVal: string, onChange: (selectedVal: string) => void): JSX.Element => {
+    const possible_values = possible_critters.length == 0 ? ['New Critter'] : [...possible_critters.map(a => a.critter_id), 'New Critter' ];
+    const value_labels = possible_critters.length == 0 ? ['New Critter'] : [...possible_critters.map(a => a.wlh_id ?? a.critter_id), 'New Critter' ];
+
     return (<Select 
       className='' //remove default styling which affects the width of this field
-      sx={{minWidth: '360px'}}
-      disabled={possible_ids.length == 0} 
+      sx={{minWidth: '160px'}}
+      disabled={possible_critters.length == 0} 
       defaultValue={defaultVal ?? 'New Critter'} 
-      values={possible_items} 
-      handleChange={onChange} />);
+      values={possible_values} 
+      handleChange={onChange} 
+      valueLabels={value_labels}/>
+    );
   }
   /**
    * TODO Add correct type for this.
@@ -170,7 +175,7 @@ const ImportAndPreviewTab = (props: ImportTabProps & { sheetIndex: SheetNames; h
         [rowIndexHeader]: idx + 2,
         [critterDropdownHeader]: 
           selectCritterDropdownElement(
-            o.row.possible_critter_ids,
+            o.row.possible_critters,
             o.row.selected_critter_id,
             (v) => {o.row.selected_critter_id = v}
           ),


### PR DESCRIPTION
Updates the table inside the Import page to include a special extra row with a dropdown element in it that displays WLH IDs of animals. You can select one to choose what critter the device / capture / markings are linked to, and you can also force a new critter to be created instead. 