### PR TITLE
JWT Auth

### DIFF
--- a/backend/js/server.js
+++ b/backend/js/server.js
@@ -101,9 +101,6 @@ const retrieveSessionInfo = function (req, res, next) {
       .send("Error: Unable to retrieve Keycloak session information");
   }
 
-  console.log(`Keycloak Access Token Content... `);
-  console.log(req.kauth.grant.access_token.content);
-
   const { family_name, given_name, email } = data;
   const sessionInfo = {
     email,
@@ -118,7 +115,6 @@ const retrieveSessionInfo = function (req, res, next) {
 // TODO: move into separate package?
 // Keycloak-protected service for proxying calls to the API host (browser -> proxy -> API)
 const proxyApi = function (req, res, next) {
-  // console.log(req.headers);
   // URL of the endpoint being targeted
   const endpoint = req.params.endpoint;
   const cbEndpoint = req.params.cbEndpoint;
@@ -133,8 +129,6 @@ const proxyApi = function (req, res, next) {
     },
     params: req.query,
   };
-
-  console.log("proxyApi options: ", options);
 
   const path = req.path.replace("/api/", "");
   let url;
@@ -177,7 +171,6 @@ const proxyApi = function (req, res, next) {
       // depending on the type of file uploaded
       // create a new formdata object to pass on to the server
       const { form, config } = file ? handleFile(file) : handleFiles(files);
-      // console.log(JSON.stringify(form, null, 2));
       api
         .post(url, form, { ...options, ...config })
         .then(successHandler)

--- a/backend/js/server.js
+++ b/backend/js/server.js
@@ -18,7 +18,6 @@ const isPublic = process.env.KEYCLOAK_CLIENT_TYPE === "public" ? true : false;
 const apiHost = `http://${process.env.BCTW_API_HOST}`;
 const apiPort = process.env.BCTW_API_PORT;
 const cbApi = process.env.CRITTERBASE_API;
-const cbApiKey = process.env.CRITTERBASE_API_KEY;
 
 console.table({ isProd, isPublic, apiHost, apiPort, sessionSalt, cbApi });
 // use Express memory store for session and Keycloak object
@@ -117,14 +116,9 @@ const retrieveSessionInfo = function (req, res, next) {
 const proxyApi = function (req, res, next) {
   // URL of the endpoint being targeted
   const endpoint = req.params.endpoint;
-  const cbEndpoint = req.params.cbEndpoint;
-  const user = req.session.user;
-  const sessionId = req.sessionID;
 
   let options = {
     headers: {
-      "api-key": cbApiKey,
-      ...user,
       Authorization: `Bearer ${req.kauth.grant.access_token.token}`,
     },
     params: req.query,

--- a/backend/js/server.js
+++ b/backend/js/server.js
@@ -17,9 +17,8 @@ const isProd = process.env.NODE_ENV === "production" ? true : false;
 const isPublic = process.env.KEYCLOAK_CLIENT_TYPE === "public" ? true : false;
 const apiHost = `http://${process.env.BCTW_API_HOST}`;
 const apiPort = process.env.BCTW_API_PORT;
-const cbApi = process.env.CRITTERBASE_API;
 
-console.table({ isProd, isPublic, apiHost, apiPort, sessionSalt, cbApi });
+console.table({ isProd, isPublic, apiHost, apiPort, sessionSalt });
 // use Express memory store for session and Keycloak object
 // var memoryStore = new expressSession.MemoryStore();
 
@@ -125,22 +124,7 @@ const proxyApi = function (req, res, next) {
   };
 
   const path = req.path.replace("/api/", "");
-  let url;
-  if (isProd) {
-    // split out the domain and username of logged-in user
-    const { domain, keycloak_guid } = getProperties(
-      req.kauth.grant.access_token.content
-    );
-
-    url = `${apiHost}:${apiPort}/${path}`;
-
-    // add parameters and username to URL
-    // Handle this inside the api
-    // url = appendQueryToUrl(url, `${domain}=${keycloak_guid}`);
-  } else {
-    // connect to API without using Keycloak authentication
-    url = `${apiHost}:${apiPort}/${path}?${parameters}`;
-  }
+  const url = `${apiHost}:${apiPort}/${path}`;
 
   const errHandler = (err) => {
     const { response } = err;

--- a/react/src/components/table/DataTable.tsx
+++ b/react/src/components/table/DataTable.tsx
@@ -68,8 +68,6 @@ export default function DataTable<T extends BCTWBase<T>>(props: DataTableProps<T
     param
     //filter
   );
-  useEffect(() => {console.log('query called')}, [data])
-  useEffect(() => {console.log(updated)}, [updated])
 
   const noPagination = !requestDataByPage && !paginationFooter;
   const noData = isSuccess && !data?.length;
@@ -80,9 +78,6 @@ export default function DataTable<T extends BCTWBase<T>>(props: DataTableProps<T
    * this state is passed to the parent select handlers
    */
   const [values, setValues] = useState<T[]>([]);
-
-
-
 
   useDidMountEffect(() => {
     if (deleted) {
@@ -125,16 +120,12 @@ export default function DataTable<T extends BCTWBase<T>>(props: DataTableProps<T
        * otherwise, query doesn't guarantee order, which can result in duplicates
        * across different pages / limitoffset
        */
-      console.log(1)
       data.forEach((d, i) => {
         const found = values.find((v) => d[rowIdentifier] === v[rowIdentifier]);
         if (!found) {
-          console.log(2)
           newV.push(d);
         }
         if (updated && d[rowIdentifier] === updated && d !== values[i]) {
-          console.log(3)
-          console.log(d)
           //If updated identifier is set, insert new data into array
           values[i] = d;
           setValues(values);
@@ -220,8 +211,6 @@ export default function DataTable<T extends BCTWBase<T>>(props: DataTableProps<T
           }
         });
 
-        // console.log('Select All Filter');
-        // console.log(updatedIds.filter((a) => a === true).length);
         setSelectedIDs(updatedIds);
       } else {
         setSelectedIDs(new Array(data.length).fill(true));

--- a/react/src/utils/common_helpers.ts
+++ b/react/src/utils/common_helpers.ts
@@ -78,8 +78,6 @@ const hasChangedProperties = <T>(original: Partial<T>, next: Partial<T>): boolea
         return true;
       }
     } else if (/*original[k] !== undefined && */next[k] !== original[k]) {
-      console.log(`Original vs Next ${JSON.stringify(original, null, 2)} ${JSON.stringify(next, null, 2)}`)
-      console.log(`hasChangedProperties evaluates true for ${k}: ${original[k]} !==  ${next[k]}`)
       return true;
     }
   }


### PR DESCRIPTION
This PR removes query-based user context from requests to bctw-api. All context is now set inside the bctw-api from the forwarded keycloak JWT. The 'authorization' header carries this token in every request.