### PR TITLE
Duplicate WLH ID fixes and others

### DIFF
--- a/react/src/api/api_interfaces.ts
+++ b/react/src/api/api_interfaces.ts
@@ -63,6 +63,7 @@ type WarningInfo = {
 type CheckedWarningInfo = WarningInfo & { checked: boolean };
 
 type AnimalCollar = Critter | Collar;
+export type ParsedAnimalCollar = AnimalCollar & {possible_critters: Pick<Critter, 'critter_id' | 'wlh_id'>[], selected_critter_id?: string}
 
 type XLSXPayload = {
   user_id: number;
@@ -70,7 +71,7 @@ type XLSXPayload = {
 };
 
 type ParsedXLSXRowResult = {
-  row: AnimalCollar & {possible_critters: Partial<Critter>[], selected_critter_id?: string};
+  row: ParsedAnimalCollar;
   errors: ParsedXLSXCellError;
   warnings: WarningInfo[];
   success: boolean;

--- a/react/src/pages/data/bulk/ExportV2.tsx
+++ b/react/src/pages/data/bulk/ExportV2.tsx
@@ -135,7 +135,7 @@ export default function ExportPageV2(): JSX.Element {
     setCritterIDs(critters);
   };
 
-  const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRadioChange = (event) => {
     // const newVal = (event.target as HTMLInputElement).value as ExportRangeType;
     const newVal = event.target.value as ExportRangeType;
     if (newVal === exportRangeType) {
@@ -170,12 +170,12 @@ export default function ExportPageV2(): JSX.Element {
           <RadioGroup row name='export-radio' value={exportRangeType}>
             <FormControlLabel
               value='lifetime'
-              control={<Radio onChange={handleRadioChange} />}
+              control={<Radio onClick={handleRadioChange} />}
               label={ExportStrings.allTelemetryButton}
             />
             <FormControlLabel
               value='last_telemetry'
-              control={<Radio onChange={handleRadioChange} />}
+              control={<Radio onClick={handleRadioChange} />}
               label={ExportStrings.mostRecentTelemetryButton}
             />
           </RadioGroup>

--- a/react/src/pages/data/bulk/WarningPromptsBanner.tsx
+++ b/react/src/pages/data/bulk/WarningPromptsBanner.tsx
@@ -5,18 +5,28 @@ type WarningPromptsBannerProps = WarningPromptsProps &
   Pick<BannerProps, 'text'> & {
     allClearText: string;
     allChecked: boolean;
+    unspecifiedCritterRows: number[]; 
   };
 /**
  *
  */
 export default function WarningPromptsBanner(props: WarningPromptsBannerProps): JSX.Element {
-  const { allClearText, text, prompts, setWarningChecked, allChecked } = props;
+  const { allClearText, text, prompts, setWarningChecked, allChecked, unspecifiedCritterRows } = props;
   return (
-    <Banner
-      variant={allChecked ? 'success' : 'warning'}
-      text={allChecked ? allClearText : text}
-      action={prompts.length > 0 ? 'collapse' : null}
-      hiddenContent={[<WarningPrompts prompts={prompts} setWarningChecked={setWarningChecked} />]}
-    />
+      unspecifiedCritterRows.length ? 
+      (<Banner 
+        variant={'warning'} 
+        text={
+        `It was not possible to determine whether some rows were existing critters or not. 
+        Please manually choose the correct critter for row${unspecifiedCritterRows.length ? 's' : ''}
+        ${unspecifiedCritterRows.join(', ')}. 
+        If none of the options appear correct, just choose New Critter.`} 
+      />) : 
+      (<Banner
+        variant={allChecked ? 'success' : 'warning'}
+        text={allChecked ? allClearText : text}
+        action={prompts.length > 0 ? 'collapse' : null}
+        hiddenContent={[<WarningPrompts prompts={prompts} setWarningChecked={setWarningChecked} />]}
+      />)
   );
 }


### PR DESCRIPTION
* Fixes radio button being stuck to one of the two options on the Export page
* Changed behavior of the dropdown menus in the import page critter select so that you are forced to choose an option if there are multiple or if there is just one and it does not match the option in the sheet.
* Added an error banner for cases where the api rejects an otherwise valid import submission.
* Added better handling for when the api rejects the parsing step of import (ie. like when you provide an out of date template)